### PR TITLE
added additional time formats

### DIFF
--- a/src/main/kotlin/org/codice/ddms/DdmsDate.kt
+++ b/src/main/kotlin/org/codice/ddms/DdmsDate.kt
@@ -31,12 +31,12 @@ private const val NOT_APPLICABLE = "Not Applicable"
 /**
  * Wrapper class for validating dates.
  *
- * DDMS only allows for the following date-time formats:
+ * DDMS allows for the following date-time formats, where TZD (time zone designation) is optional:
  * - `yyyy-MM-dd'T'hh:mm:ss.sTZD`
- * - `yyyy-MM-dd'T'hh:mm:ss`
- * - `yyyy-MM-dd`
- * - `yyyy-MM`
- * - `yyyy`
+ * - `yyyy-MM-dd'T'hh:mm:ssTZD`
+ * - `yyyy-MM-ddTZD`
+ * - `yyyy-MMTZD`
+ * - `yyyyTZD`
  * - `Unknown`
  * - `Not Applicable`
  *

--- a/src/main/kotlin/org/codice/ddms/DdmsDate.kt
+++ b/src/main/kotlin/org/codice/ddms/DdmsDate.kt
@@ -5,24 +5,22 @@ http://www.gnu.org/licenses/lgpl.html
 */
 package org.codice.ddms
 
-import java.lang.IllegalArgumentException
 import java.time.DateTimeException
-import java.time.temporal.TemporalAccessor
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatterBuilder
 import java.time.format.DateTimeParseException
+import java.time.temporal.TemporalAccessor
 
 private val datetimeFormatter = DateTimeFormatterBuilder()
+        .appendOptional(DateTimeFormatter.ISO_INSTANT)
         .appendOptional(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
         .appendOptional(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
         .appendOptional(DateTimeFormatter.ISO_OFFSET_DATE)
+        .appendOptional(DateTimeFormatter.ofPattern("yyyy-MMXXX"))
         .appendOptional(DateTimeFormatter.ISO_LOCAL_DATE)
-        .appendOptional(DateTimeFormatter.ISO_INSTANT)
-        .appendOptional(DateTimeFormatter.ofPattern("yyyy[XXX]"))
-        .toFormatter()
-
-private val yearMonthFormatter = DateTimeFormatterBuilder()
-        .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM[XXX]"))
+        .appendOptional(DateTimeFormatter.ofPattern("yyyyXXX"))
+        .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM"))
+        .appendOptional(DateTimeFormatter.ofPattern("yyyy"))
         .toFormatter()
 
 private const val UNKNOWN = "Unknown"
@@ -69,12 +67,7 @@ class DdmsDate {
                 datetimeFormatter.parse(date)
                 true
             } catch (ignore: DateTimeParseException) {
-                return try {
-                    yearMonthFormatter.parse(date)
-                    true
-                } catch(ignore: DateTimeParseException) {
-                    false
-                }
+                false
             }
         }
 
@@ -88,12 +81,7 @@ class DdmsDate {
                 datetimeFormatter.format(date)
                 true
             } catch (ignore: DateTimeException) {
-                return try {
-                    yearMonthFormatter.format(date)
-                    true
-                } catch(ignore: DateTimeParseException) {
-                    false
-                }
+                false
             }
         }
     }
@@ -146,8 +134,9 @@ class DdmsDate {
      * @return The [TemporalAccessor] of the date.
      * @throws IllegalStateException when [parsedDate] is [DdmsDate.unknown] or [DdmsDate.notApplicable].
      */
-    fun toRawTemporalAccessor(): TemporalAccessor = parsedDate ?: throw IllegalStateException("DdmsDate is either " +
-            "Unknown or Not Applicable. Can't be converted to TemporalAccessor.")
+    fun toRawTemporalAccessor(): TemporalAccessor = parsedDate
+            ?: throw IllegalStateException("DdmsDate is either " +
+                    "Unknown or Not Applicable. Can't be converted to TemporalAccessor.")
 
     /**
      * Outputs the date in a human-readable format.

--- a/src/main/kotlin/org/codice/ddms/DdmsDate.kt
+++ b/src/main/kotlin/org/codice/ddms/DdmsDate.kt
@@ -7,17 +7,22 @@ package org.codice.ddms
 
 import java.lang.IllegalArgumentException
 import java.time.DateTimeException
+import java.time.temporal.TemporalAccessor
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatterBuilder
 import java.time.format.DateTimeParseException
-import java.time.temporal.TemporalAccessor
 
 private val datetimeFormatter = DateTimeFormatterBuilder()
         .appendOptional(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
         .appendOptional(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        .appendOptional(DateTimeFormatter.ISO_OFFSET_DATE)
         .appendOptional(DateTimeFormatter.ISO_LOCAL_DATE)
-        .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM"))
-        .appendOptional(DateTimeFormatter.ofPattern("yyyy"))
+        .appendOptional(DateTimeFormatter.ISO_INSTANT)
+        .appendOptional(DateTimeFormatter.ofPattern("yyyy[XXX]"))
+        .toFormatter()
+
+private val yearMonthFormatter = DateTimeFormatterBuilder()
+        .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM[XXX]"))
         .toFormatter()
 
 private const val UNKNOWN = "Unknown"
@@ -64,7 +69,12 @@ class DdmsDate {
                 datetimeFormatter.parse(date)
                 true
             } catch (ignore: DateTimeParseException) {
-                false
+                return try {
+                    yearMonthFormatter.parse(date)
+                    true
+                } catch(ignore: DateTimeParseException) {
+                    false
+                }
             }
         }
 
@@ -78,7 +88,12 @@ class DdmsDate {
                 datetimeFormatter.format(date)
                 true
             } catch (ignore: DateTimeException) {
-                false
+                return try {
+                    yearMonthFormatter.format(date)
+                    true
+                } catch(ignore: DateTimeParseException) {
+                    false
+                }
             }
         }
     }

--- a/src/test/kotlin/org/codice/ddms/DdmsDateTest.kt
+++ b/src/test/kotlin/org/codice/ddms/DdmsDateTest.kt
@@ -5,15 +5,16 @@ http://www.gnu.org/licenses/lgpl.html
 */
 package org.codice.ddms
 
-import org.hamcrest.CoreMatchers.`is`
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Test
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.Year
 import java.time.YearMonth
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
 
 class DdmsDateTest {
     @Test
@@ -41,6 +42,24 @@ class DdmsDateTest {
     }
 
     @Test
+    fun `Date with Z offset is valid`() {
+        val date = "2007-04-03Z"
+        assertThat(DdmsDate.isValid(date), `is`(true))
+    }
+
+    @Test
+    fun `Date with positive offset is valid`() {
+        val date = "2007-04-03+03:00"
+        assertThat(DdmsDate.isValid(date), `is`(true))
+    }
+
+    @Test
+    fun `Date with negative offset is valid`() {
+        val date = "2007-04-03-03:00"
+        assertThat(DdmsDate.isValid(date), `is`(true))
+    }
+
+    @Test
     fun `LocalDate is valid`() {
         val date = LocalDate.now()
         assertThat(DdmsDate.isValid(date), `is`(true))
@@ -50,6 +69,42 @@ class DdmsDateTest {
     fun `LocalDate string is valid`() {
         val date = LocalDate.now().toString()
         assertThat(DdmsDate.isValid(date), `is`(true))
+    }
+
+    @Test
+    fun `Instant is valid`() {
+        val date = Instant.now()
+        assertThat(DdmsDate.isValid(date), `is`(true))
+    }
+
+    @Test
+    fun `Instant string is valid`() {
+        val date = "2013-07-06T10:59:25.090-04:00"
+        assertThat(DdmsDate.isValid(date), `is`(true))
+    }
+
+    @Test
+    fun `Year month with Z offset is valid`() {
+        val date = "2003-04Z"
+        assertThat(DdmsDate.isValid(date), `is`(true))
+    }
+
+    @Test
+    fun `Year month with positive offset is valid`() {
+        val date = "2007-04+03:00"
+        assertThat(DdmsDate.isValid(date), `is`(true))
+    }
+
+    @Test
+    fun `Year month with negative offset is valid`() {
+        val date = "2007-04-03:00"
+        assertThat(DdmsDate.isValid(date), `is`(true))
+    }
+
+    @Test
+    fun `Year month with offset no colon is not valid`() {
+        val date = "2007-04+0300"
+        assertThat(DdmsDate.isValid(date), `is`(false))
     }
 
     @Test
@@ -63,6 +118,25 @@ class DdmsDateTest {
         val date = YearMonth.now().toString()
         assertThat(DdmsDate.isValid(date), `is`(true))
     }
+
+    @Test
+    fun `Year with Z offset is valid`() {
+        val date = "2007Z"
+        assertThat(DdmsDate.isValid(date), `is`(true))
+    }
+
+    @Test
+    fun `Year with negative offset is valid`() {
+        val date = "2007-03:00"
+        assertThat(DdmsDate.isValid(date), `is`(true))
+    }
+
+    @Test
+    fun `Year with positive offset is valid`() {
+        val date = "2007+03:00"
+        assertThat(DdmsDate.isValid(date), `is`(true))
+    }
+
 
     @Test
     fun `Year is valid`() {

--- a/src/test/kotlin/org/codice/ddms/DdmsDateTest.kt
+++ b/src/test/kotlin/org/codice/ddms/DdmsDateTest.kt
@@ -137,7 +137,6 @@ class DdmsDateTest {
         assertThat(DdmsDate.isValid(date), `is`(true))
     }
 
-
     @Test
     fun `Year is valid`() {
         val date = Year.now()


### PR DESCRIPTION
Having a time zone designation on `yyyy`, `yyyy-MM` and `yyyy-MM-dd` formats is valid according to the DDMS schema, but DdmsDate's `isValid`  was returning false