### PR TITLE
BR-49 Update openddms to run on changes, instead of nightly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
         timestamps()
     }
     triggers {
-        cron(env.BRANCH_NAME == "master" ? "H H(21-23) * * *" : "")
+        pollSCM(env.BRANCH_NAME == "master" ? "H H(21-23) * * *" : "")
     }
     environment {
         GITHUB_USERNAME = 'codice'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,9 +16,6 @@ pipeline {
         disableConcurrentBuilds()
         timestamps()
     }
-    triggers {
-        pollSCM(env.BRANCH_NAME == "master" ? "H H(21-23) * * *" : "")
-    }
     environment {
         GITHUB_USERNAME = 'codice'
         GITHUB_REPONAME = 'openddms'


### PR DESCRIPTION
# Update openddms to run on changes instead of nightly

## What does this PR do?

The job has been running nightly for months but there has been no changes to the code, so the change will just be to run it if there is a code change. 

This will be done by removing the trigger from the Jenkinsfile

## Testing
There is a job on Jenkins-test where this has been run and the new triggering enacted
http://jenkins-test.phx.connexta.com/service/jenkins-test/job/openddms-morrison/
 
## Reviewers
@shaundmorris
@LinkMJB  
@AdamBurstynski 
@AzGoalie 



